### PR TITLE
Created Local Scripts for Linux and Windows

### DIFF
--- a/.github/workflows/recovery.yml
+++ b/.github/workflows/recovery.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Prepare the environment
       run: |
-        sudo apt install git wget lz4 tar openssl python3 -y
+        sudo apt install git wget tar openssl python3 -y
 
     - name: Fetch image from URL
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Files
 *.img
+*.tar
 *.exe
 
 # Folders

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Files
+*.img
+*.exe
+
+# Folders
+.idea

--- a/README.md
+++ b/README.md
@@ -2,14 +2,21 @@
 This CI service patches recovery images of Samsung to enable Fastbootd. Based on Phh's [script](https://github.com/phhusson/samsung-galaxy-a51-gsi-boot)
 
 # How to use:
+## Method 1 - Using GitHub
 - Fork this repo.
-- Extract your recovery.img.lz4 and upload recovery.img (not lz4) to [transfer.sh](https://transfer.sh/) or any other file hosting sites. Once uploaded right click on the Download button and copy the URL. Avoid Gdrive links for now as it has been causing an error in some cases. 
-- Head over to Actions tab. Click on RECOVERY -> Run workflow. Insert the copied URL in the RECOVERY URL field and Start the workflow
+- Extract your recovery.img.lz4 and upload recovery.img or recovery.img.lz4 to [transfer.sh](https://transfer.sh/) or any other file hosting sites. Once uploaded right click on the Download button and copy the URL. Avoid Gdrive links for now as it has been causing an error in some cases. 
+- Head over to Actions tab. Click on RECOVERY -> Run workflow. Insert the copied URL in the RECOVERY URL field and Start the workflow.
 - The Patching process will start
-- A Patched-Recovery.zip will be uploaded at the end of the process. Download it and extract your patched recovery image. The Image will already also be repacked to .tar for flashing directly through Odin
+- The file Patched-Recovery.zip will be uploaded at the end of the process. Download it and extract your patched recovery image. The Image will already also be repacked to .tar for flashing directly through Odin.
 ![](https://s3.bmp.ovh/imgs/2022/04/19/91ef3a3ee9255e9c.png)
 - Flash vbmeta_disabled_r if needed
 
+## Method 2 - Running Locally (Supports Windows and Linux)
+- Download the appropriate file, either patchrecovery.bat (Windows) or patchrecovery.sh (Linux).
+- Place the recovery image (recovery.img or recovery.img.lz4) in the same directory as the script.
+- Open a command-line in the same directory and run the script by typing "patchrecovery".
+- The file patched-recovery.tar will be created and can now be flashed using a program such as Odin.
+
 # Credits
-- [Phhusson](https://github.com/phhusson) Without his script nothing would be possible at the first place
-- [James Nguyen](https://github.com/thongass000) Helping me in simplifying the scripts and tweaking it
+- [Phhusson](https://github.com/phhusson) Without his script nothing would be possible in the first place.
+- [James Nguyen](https://github.com/thongass000) Helping me in simplifying the scripts and tweaking it.

--- a/patchrecovery.bat
+++ b/patchrecovery.bat
@@ -38,7 +38,8 @@ if exist recovery.img.lz4 (
 
 if not exist recovery.img (
 	echo No file found, please supply a recovery image to patch.
-    exit \b
+	pause >NUL 2>&1
+    exit /b
 )
 
 ::::::::::::::

--- a/patchrecovery.bat
+++ b/patchrecovery.bat
@@ -1,0 +1,90 @@
+@echo off
+
+setlocal
+
+::::::::::::::::::
+:: Dependencies ::
+::::::::::::::::::
+
+if not exist lz4.exe (
+    echo Downloading lz4...
+    for /f "tokens=1,* delims=:" %%a in ('curl -s https://api.github.com/repos/lz4/lz4/releases/latest ^| find "browser_download_url" ^| find "lz4_win64"') do (curl -kOL %%b)
+    ren lz4* lz4.zip
+    tar -xf lz4.zip lz4.exe
+    del lz4.zip
+)
+
+if not exist magiskboot.exe (
+    echo Downloading magiskboot...
+    for /f "tokens=1,* delims=:" %%a in ('curl -ks https://api.github.com/repos/svoboda18/magiskboot/releases/latest ^| find "browser_download_url" ^| find "magiskboot.zip"') do (curl -kOL %%b)
+    tar -xf magiskboot.zip
+    del Magiskboot.zip
+)
+
+::::::::::::::::::::
+:: Initialization ::
+::::::::::::::::::::
+
+del patched-recovery.tar >NUL 2>&1
+
+ren *.img.lz4 recovery.img.lz4 >NUL 2>&1
+ren *.img recovery.img >NUL 2>&1
+
+if exist recovery.img.lz4 (
+    echo Decompressing the lz4 image...
+    lz4 -B6 --content-size -f recovery.img.lz4 recovery.img
+    del recovery.img.lz4
+)
+
+if not exist recovery.img (
+	echo No file found, please supply a recovery image to patch.
+    exit \b
+)
+
+::::::::::::::
+:: Patching ::
+::::::::::::::
+
+mkdir temp
+cd temp || exit /b
+
+..\magiskboot unpack ../recovery.img
+..\magiskboot cpio ramdisk.cpio extract
+..\magiskboot hexpatch ramdisk/system/bin/recovery e10313aaf40300aa6ecc009420010034 e10313aaf40300aa6ecc0094
+..\magiskboot hexpatch ramdisk/system/bin/recovery eec3009420010034 eec3009420010035
+..\magiskboot hexpatch ramdisk/system/bin/recovery 3ad3009420010034 3ad3009420010035
+..\magiskboot hexpatch ramdisk/system/bin/recovery 50c0009420010034 50c0009420010035
+..\magiskboot hexpatch ramdisk/system/bin/recovery 080109aae80000b4 080109aae80000b5
+..\magiskboot hexpatch ramdisk/system/bin/recovery 20f0a6ef38b1681c 20f0a6ef38b9681c
+..\magiskboot hexpatch ramdisk/system/bin/recovery 23f03aed38b1681c 23f03aed38b9681c
+..\magiskboot hexpatch ramdisk/system/bin/recovery 20f09eef38b1681c 20f09eef38b9681c
+..\magiskboot hexpatch ramdisk/system/bin/recovery 26f0ceec30b1681c 26f0ceec30b9681c
+..\magiskboot hexpatch ramdisk/system/bin/recovery 24f0fcee30b1681c 24f0fcee30b9681c
+..\magiskboot hexpatch ramdisk/system/bin/recovery 27f02eeb30b1681c 27f02eeb30b9681c
+..\magiskboot hexpatch ramdisk/system/bin/recovery b4f082ee28b1701c b4f082ee28b970c1
+..\magiskboot hexpatch ramdisk/system/bin/recovery 9ef0f4ec28b1701c 9ef0f4ec28b9701c
+..\magiskboot cpio ramdisk.cpio "add 0755 ramdisk/system/bin/recovery ramdisk/system/bin/recovery"
+..\magiskboot repack ../recovery.img ../recovery-patched.img
+
+cd.. || exit /b
+rmdir /S /Q temp
+
+:::::::::::::
+:: Zipping ::
+:::::::::::::
+
+mkdir output
+cd output || exit /b
+
+move ..\recovery-patched.img recovery.img >NUL 2>&1
+tar cvf patched-recovery.tar recovery.img >NUL 2>&1
+move patched-recovery.tar ../patched-recovery.tar >NUL 2>&1
+
+cd .. || exit /b
+rmdir /S /Q output
+
+echo.
+echo Done! Flash the file 'patched-recovery.tar' to finsh installation.
+
+pause >NUL 2>&1
+exit /b

--- a/patchrecovery.bat
+++ b/patchrecovery.bat
@@ -6,14 +6,6 @@ setlocal
 :: Dependencies ::
 ::::::::::::::::::
 
-if not exist lz4.exe (
-    echo Downloading lz4...
-    for /f "tokens=1,* delims=:" %%a in ('curl -s https://api.github.com/repos/lz4/lz4/releases/latest ^| find "browser_download_url" ^| find "lz4_win64"') do (curl -kOL %%b)
-    ren lz4* lz4.zip
-    tar -xf lz4.zip lz4.exe
-    del lz4.zip
-)
-
 if not exist magiskboot.exe (
     echo Downloading magiskboot...
     for /f "tokens=1,* delims=:" %%a in ('curl -ks https://api.github.com/repos/svoboda18/magiskboot/releases/latest ^| find "browser_download_url" ^| find "magiskboot.zip"') do (curl -kOL %%b)
@@ -32,8 +24,7 @@ ren *.img recovery.img >NUL 2>&1
 
 if exist recovery.img.lz4 (
     echo Decompressing the lz4 image...
-    lz4 -B6 --content-size -f recovery.img.lz4 recovery.img
-    del recovery.img.lz4
+    magiskboot decompress recovery.img.lz4
 )
 
 if not exist recovery.img (

--- a/patchrecovery.bat
+++ b/patchrecovery.bat
@@ -42,20 +42,29 @@ cd temp || exit /b
 
 ..\magiskboot unpack ../recovery.img
 ..\magiskboot cpio ramdisk.cpio extract
-..\magiskboot hexpatch ramdisk/system/bin/recovery e10313aaf40300aa6ecc009420010034 e10313aaf40300aa6ecc0094
-..\magiskboot hexpatch ramdisk/system/bin/recovery eec3009420010034 eec3009420010035
-..\magiskboot hexpatch ramdisk/system/bin/recovery 3ad3009420010034 3ad3009420010035
-..\magiskboot hexpatch ramdisk/system/bin/recovery 50c0009420010034 50c0009420010035
-..\magiskboot hexpatch ramdisk/system/bin/recovery 080109aae80000b4 080109aae80000b5
-..\magiskboot hexpatch ramdisk/system/bin/recovery 20f0a6ef38b1681c 20f0a6ef38b9681c
-..\magiskboot hexpatch ramdisk/system/bin/recovery 23f03aed38b1681c 23f03aed38b9681c
-..\magiskboot hexpatch ramdisk/system/bin/recovery 20f09eef38b1681c 20f09eef38b9681c
-..\magiskboot hexpatch ramdisk/system/bin/recovery 26f0ceec30b1681c 26f0ceec30b9681c
-..\magiskboot hexpatch ramdisk/system/bin/recovery 24f0fcee30b1681c 24f0fcee30b9681c
-..\magiskboot hexpatch ramdisk/system/bin/recovery 27f02eeb30b1681c 27f02eeb30b9681c
-..\magiskboot hexpatch ramdisk/system/bin/recovery b4f082ee28b1701c b4f082ee28b970c1
-..\magiskboot hexpatch ramdisk/system/bin/recovery 9ef0f4ec28b1701c 9ef0f4ec28b9701c
-..\magiskboot cpio ramdisk.cpio "add 0755 ramdisk/system/bin/recovery ramdisk/system/bin/recovery"
+
+cd ramdisk || exit /b
+for %%a in (*) do move "%%a" ..
+for /d %%a in (*) do move "%%a" ..
+cd .. || exit /b
+
+del cpio
+rmdir /S /Q ramdisk
+
+..\magiskboot hexpatch system/bin/recovery e10313aaf40300aa6ecc009420010034 e10313aaf40300aa6ecc0094
+..\magiskboot hexpatch system/bin/recovery eec3009420010034 eec3009420010035
+..\magiskboot hexpatch system/bin/recovery 3ad3009420010034 3ad3009420010035
+..\magiskboot hexpatch system/bin/recovery 50c0009420010034 50c0009420010035
+..\magiskboot hexpatch system/bin/recovery 080109aae80000b4 080109aae80000b5
+..\magiskboot hexpatch system/bin/recovery 20f0a6ef38b1681c 20f0a6ef38b9681c
+..\magiskboot hexpatch system/bin/recovery 23f03aed38b1681c 23f03aed38b9681c
+..\magiskboot hexpatch system/bin/recovery 20f09eef38b1681c 20f09eef38b9681c
+..\magiskboot hexpatch system/bin/recovery 26f0ceec30b1681c 26f0ceec30b9681c
+..\magiskboot hexpatch system/bin/recovery 24f0fcee30b1681c 24f0fcee30b9681c
+..\magiskboot hexpatch system/bin/recovery 27f02eeb30b1681c 27f02eeb30b9681c
+..\magiskboot hexpatch system/bin/recovery b4f082ee28b1701c b4f082ee28b970c1
+..\magiskboot hexpatch system/bin/recovery 9ef0f4ec28b1701c 9ef0f4ec28b9701c
+..\magiskboot cpio ramdisk.cpio "add 0755 system/bin/recovery system/bin/recovery"
 ..\magiskboot repack ../recovery.img ../recovery-patched.img
 
 cd.. || exit /b

--- a/patchrecovery.sh
+++ b/patchrecovery.sh
@@ -7,9 +7,9 @@
 echo "Checking for dependencies..."
 
 if [ -e "/etc/debian_version" ]; then  # Checking to determine the linux distro.
-  sudo apt install curl unzip tar lz4 -y &>/dev/null
+  sudo apt install curl unzip tar -y &>/dev/null
 elif [ -e "/etc/arch-release" ]; then
-  sudo pacman -Syu curl unzip tar lz4 &>/dev/null
+  sudo pacman -Syu curl unzip tar &>/dev/null
 else
   echo "No available package manager found, this program cannot run on your computer."
   exit 1
@@ -26,13 +26,12 @@ fi
 
 rm -rf patched-recovery.tar  # Deleting the old patched recovery if exists.
 
-mv *.img.lz4 recovery.img.lz4 &>/dev/null  # Renames the lz4 file if found.
-mv *.img recovery.img &>/dev/null  # Renames the img file if found.
+mv -- *.img.lz4 recovery.img.lz4 &>/dev/null  # Renames the lz4 file if found.
+mv -- *.img recovery.img &>/dev/null  # Renames the img file if found.
 
 if [ -e recovery.img.lz4 ];then  # Decompresses the recovery file if in lz4 format.
   echo "Decompressing the lz4 image..."
-	lz4 -B6 --content-size -f recovery.img.lz4 recovery.img
-	rm -rf recovery.img.lz4
+	./magiskboot decompress recovery.img.lz4
 fi
 
 if ! [ -e recovery.img ]; then  # Checking for the existence of the file passed as an argument.

--- a/patchrecovery.sh
+++ b/patchrecovery.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+################
+# Dependencies #
+################
+
+echo "Checking for dependencies..."
+
+if [ -e "/etc/debian_version" ]; then  # Checking to determine the linux distro.
+  sudo apt install curl unzip tar lz4 -y &>/dev/null
+elif [ -e "/etc/arch-release" ]; then
+  sudo pacman -Syu curl unzip tar lz4 &>/dev/null
+else
+  echo "No available package manager found, this program cannot run on your computer."
+  exit 1
+fi
+
+if ! [ -e magiskboot ]; then  # Downloading Magiskboot directly from Github.
+    echo "Download magiskboot..."
+    curl -s https://api.github.com/repos/topjohnwu/Magisk/releases/latest | grep "browser_download_url" | cut -d : -f 2,3 | tr -d \" | wget -qi -
+    unzip -joq Magisk*.apk lib/x86_64/libmagiskboot.so
+    mv libmagiskboot.so magiskboot
+    rm -rf Magisk*.apk
+fi
+
+##################
+# Initialization #
+##################
+
+rm -rf patched-recovery.tar  # Deleting the old patched recovery if exists.
+
+mv *.img.lz4 recovery.img.lz4 &>/dev/null  # Renames the lz4 file if found.
+mv *.img recovery.img &>/dev/null  # Renames the img file if found.
+
+if [ -e recovery.img.lz4 ];then  # Decompresses the recovery file if in lz4 format.
+  echo "Decompressing the lz4 image..."
+	lz4 -B6 --content-size -f recovery.img.lz4 recovery.img
+	rm -rf recovery.img.lz4
+fi
+
+if ! [ -e recovery.img ]; then  # Checking for the existence of the file passed as an argument.
+	echo "No file found, please supply a recovery image file to patch."
+	exit 1
+fi
+
+############
+# Patching #
+############
+
+mkdir temp
+cd temp || exit 1
+
+../magiskboot unpack ../temp.img
+../magiskboot cpio ramdisk.cpio extract
+../magiskboot hexpatch system/bin/recovery e10313aaf40300aa6ecc009420010034 e10313aaf40300aa6ecc0094
+../magiskboot hexpatch system/bin/recovery eec3009420010034 eec3009420010035
+../magiskboot hexpatch system/bin/recovery 3ad3009420010034 3ad3009420010035
+../magiskboot hexpatch system/bin/recovery 50c0009420010034 50c0009420010035
+../magiskboot hexpatch system/bin/recovery 080109aae80000b4 080109aae80000b5
+../magiskboot hexpatch system/bin/recovery 20f0a6ef38b1681c 20f0a6ef38b9681c
+../magiskboot hexpatch system/bin/recovery 23f03aed38b1681c 23f03aed38b9681c
+../magiskboot hexpatch system/bin/recovery 20f09eef38b1681c 20f09eef38b9681c
+../magiskboot hexpatch system/bin/recovery 26f0ceec30b1681c 26f0ceec30b9681c
+../magiskboot hexpatch system/bin/recovery 24f0fcee30b1681c 24f0fcee30b9681c
+../magiskboot hexpatch system/bin/recovery 27f02eeb30b1681c 27f02eeb30b9681c
+../magiskboot hexpatch system/bin/recovery b4f082ee28b1701c b4f082ee28b970c1
+../magiskboot hexpatch system/bin/recovery 9ef0f4ec28b1701c 9ef0f4ec28b9701c
+../magiskboot cpio ramdisk.cpio 'add 0755 system/bin/recovery system/bin/recovery'
+../magiskboot repack ../temp.img ../recovery-patched.img
+
+cd .. || exit 1
+rm -rf temp temp.img
+
+###########
+# Zipping #
+###########
+
+mkdir output
+cd output || exit 1
+
+mv ../recovery-patched.img recovery.img
+tar cvf patched-recovery.tar recovery.img
+mv patched-recovery.tar ../patched-recovery.tar
+
+cd .. || exit 1
+rm -rf output
+
+echo ""
+echo "Done! Flash the file 'patched-recovery.tar.md5' to finsh installation."
+
+exit 0

--- a/patchrecovery.sh
+++ b/patchrecovery.sh
@@ -15,12 +15,9 @@ else
   exit 1
 fi
 
-if ! [ -e magiskboot ]; then  # Downloading Magiskboot directly from Github.
+if ! [ -e magiskboot ]; then  # Downloads Magiskboot directly from Github.
     echo "Download magiskboot..."
-    curl -s https://api.github.com/repos/topjohnwu/Magisk/releases/latest | grep "browser_download_url" | cut -d : -f 2,3 | tr -d \" | wget -qi -
-    unzip -joq Magisk*.apk lib/x86_64/libmagiskboot.so
-    mv libmagiskboot.so magiskboot
-    rm -rf Magisk*.apk
+    curl -kOL https://github.com/Johx22/Patch-Recovery/raw/master/magiskboot
 fi
 
 ##################
@@ -50,7 +47,7 @@ fi
 mkdir temp
 cd temp || exit 1
 
-../magiskboot unpack ../temp.img
+../magiskboot unpack ../recovery.img
 ../magiskboot cpio ramdisk.cpio extract
 ../magiskboot hexpatch system/bin/recovery e10313aaf40300aa6ecc009420010034 e10313aaf40300aa6ecc0094
 ../magiskboot hexpatch system/bin/recovery eec3009420010034 eec3009420010035
@@ -66,10 +63,10 @@ cd temp || exit 1
 ../magiskboot hexpatch system/bin/recovery b4f082ee28b1701c b4f082ee28b970c1
 ../magiskboot hexpatch system/bin/recovery 9ef0f4ec28b1701c 9ef0f4ec28b9701c
 ../magiskboot cpio ramdisk.cpio 'add 0755 system/bin/recovery system/bin/recovery'
-../magiskboot repack ../temp.img ../recovery-patched.img
+../magiskboot repack ../recovery.img ../recovery-patched.img
 
 cd .. || exit 1
-rm -rf temp temp.img
+rm -rf temp
 
 ###########
 # Zipping #

--- a/script1.sh
+++ b/script1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -f recovery.img.lz4 ];then
-	lz4 -B6 --content-size -f recovery.img.lz4 recovery.img
+	./magiskboot decompress recovery.img.lz4
 fi
 
 off=$(grep -ab -o SEANDROIDENFORCE recovery.img |tail -n 1 |cut -d : -f 1)


### PR DESCRIPTION
I created versions of this program that are meant to be run on users computers locally, this should be done for two reasons:
- It allows the program to be portable, meaning that it does not require GitHub to work and can be run without an internet connection.
- Though we can see the exact code being run (in recovery.yml), some users may view downloading a file created by a GitHub workflow as a security risk, as the code is being run on an external machine.

I made some further modification to the scripts, they are as follow:
- It is generally not a good idea to include static binaries with a program (avbtool, magiskboot), my script downloads the programs directly from the appropriate source.
- In script1.sh there is a line of code `dd if=recovery.img of=r.img bs=4k count=$off iflag=count_bytes`, however it is not needed as well as the use of the avbtool. 

**Rationale** - The "dd" line shrinks the img file by removing the hash and footer, then the avbtool reinserts new ones at the end of the patching process. This is not needed because magiskboot can just patch the file in-place and the img will flash through Odin properly. This is good because it reduces the number of steps that the script needs to execute and reduces the reliance on additional programs such as the avbtool and opensll.

If you want to include the commands I removed in the local script for Linux, that is perfectly fine but note that the avbtool does not work on Windows, so if the hash and footer are removed they cannot be reinserted, as such the windows script must remain as is.

Lastly I added a simple explanation of how to use the local scripts in the README.md. 