### PR TITLE
Outdated dependencies in the recovery.yml workflow file

### DIFF
--- a/.github/workflows/recovery.yml
+++ b/.github/workflows/recovery.yml
@@ -48,7 +48,7 @@ jobs:
         mv fastbootd-recovery.tar fastbootd-recovery.tar.md5
 
     - name: Upload Recovery
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4
       with:
         path: /home/runner/work/Patch-Recovery/Patch-Recovery/output/*.md5
         name: Patched-Recovery

--- a/.github/workflows/recovery.yml
+++ b/.github/workflows/recovery.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Check Out


### PR DESCRIPTION
The recovery.yml workflow file uses outdated dependencies, them being Ubuntu 20.04 and upload-artifact v3. These versions are both deprecated by Github, and so the action cannot be run anymore. The solution is chaging the recovery.yml file to use Ubuntu 24.04 and upload-artifact v4, fixing the problem and making the code run properly again :)
