### PR TITLE
Ending support for Ubuntu 20.04 LTS

### DIFF
--- a/.github/workflows/recovery.yml
+++ b/.github/workflows/recovery.yml
@@ -48,7 +48,7 @@ jobs:
         mv fastbootd-recovery.tar fastbootd-recovery.tar.md5
 
     - name: Upload Recovery
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4
       with:
         path: /home/runner/work/Patch-Recovery/Patch-Recovery/output/*.md5
         name: Patched-Recovery

--- a/.github/workflows/recovery.yml
+++ b/.github/workflows/recovery.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Check Out


### PR DESCRIPTION
This doesnt make sense why the f*ck ubuntu 20.04 LTS is ending support