### PR TITLE
Fix workflow deprecations and runner issues in RECOVERY workflow

### DIFF
--- a/.github/workflows/recovery.yml
+++ b/.github/workflows/recovery.yml
@@ -48,7 +48,7 @@ jobs:
         mv fastbootd-recovery.tar fastbootd-recovery.tar.md5
 
     - name: Upload Recovery
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4
       with:
         path: /home/runner/work/Patch-Recovery/Patch-Recovery/output/*.md5
         name: Patched-Recovery

--- a/.github/workflows/recovery.yml
+++ b/.github/workflows/recovery.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Check Out

--- a/.github/workflows/recovery.yml
+++ b/.github/workflows/recovery.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Check Out


### PR DESCRIPTION
1. Changed `runs-on` from `ubuntu-20.04` to `ubuntu-latest` to avoid using a deprecated runner.  
2. Updated `actions/upload-artifact` from v3.0.0 to v4 to fix automatic failure due to deprecation.  